### PR TITLE
Fix incorrect usage of is_open in Python 3.

### DIFF
--- a/thrift_sasl/six.py
+++ b/thrift_sasl/six.py
@@ -44,5 +44,5 @@ if PY3:
   from io import BytesIO as StringIO
   from thriftpy.transport import TTransportException, TTransportBase, readall
 
-  is_open_compat = lambda trans: trans.is_open()
+  is_open_compat = lambda trans: trans.isOpen()
   read_all_compat = lambda trans, sz: readall(trans.read, sz)


### PR DESCRIPTION
Greetings!

I am trying to port a project to Python 3, and am almost there... but it depends on the thrift_sasl module, and it appears that it assumes a change to the `TTransportBase` API which is not present in the Apache library. Namely, `TTransportBase.isOpen` does not seem to change to `TTransportBase.is_open` under Python 3. This patch fixes this.

Best,
M

@wesm : As you are the latest person to commit to the repository, can you maybe take a look?
