### PR TITLE
Support transports with camelCase method names

### DIFF
--- a/thrift_sasl/six.py
+++ b/thrift_sasl/six.py
@@ -44,5 +44,11 @@ if PY3:
   from io import BytesIO as StringIO
   from thriftpy.transport import TTransportException, TTransportBase, readall
 
-  is_open_compat = lambda trans: trans.is_open()
+  def is_open_compat(trans):
+    try:
+      is_open = trans.is_open()
+    except AttributeError:
+      is_open = trans.isOpen()
+    return is_open
+
   read_all_compat = lambda trans, sz: readall(trans.read, sz)


### PR DESCRIPTION
Thrift works with Python 3, but [has not renamed the `isOpen` method](https://github.com/eevans/python-thrift/blob/master/src/transport/TTransport.py#L42). Maybe it
will in future, so I've kept the check defensive, and optimistically
choose the pythonic version.
