### PR TITLE
Make compatible with Apache Thrift's isOpen and thriftpy's is_open

### DIFF
--- a/thrift_sasl/__init__.py
+++ b/thrift_sasl/__init__.py
@@ -58,13 +58,18 @@ class TSaslClientTransport(TTransportBase, CReadableTransport):
     self.encode = None
 
   def isOpen(self):
-    return self._trans.is_open()
+    try:
+      is_open = self._trans.isOpen # Thrift
+    except AttributeError:
+      is_open = self._trans.is_open # thriftpy
+
+    return is_open()
 
   def is_open(self):
     return self.isOpen()
 
   def open(self):
-    if not self._trans.is_open():
+    if not self.isOpen():
       self._trans.open()
 
     if self.sasl is not None:


### PR DESCRIPTION
Looks like a previous commit began to mismatch the Thrift's ```TSocket.isOpen``` with ```is_open```, causing #12, which this PR should fix. This reverts to ```isOpen``` consistent with Thrift:

https://git1-us-west.apache.org/repos/asf?p=thrift.git;a=blob;f=lib/py/src/transport/TSocket.py;h=c91de9d701f8e26f1fcadf2e2b4c6eb79bc7b3ed;hb=HEAD#l72

Or is there another ```TSocket``` out there that has ```is_open```? I'm trying to figure out how both of these issues can occur: cloudera/impyla#268 and #12. Note that the dropbox/PyHive build has been failing since the change to ```is_open```:

https://travis-ci.org/dropbox/PyHive/jobs/351872837

