### PR TITLE
Use six.ensure_binary() to convert strings into bytes in _send_message().

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         # Installing sasl on Windows is rather painful, so use the pure python
         # implementation on Windows
         'pure-sasl>=0.3.0' if WINDOWS else 'sasl>=0.2.1',
+        'six>=1.13.0'
     ],
     packages=['thrift_sasl'],
     keywords='thrift sasl transport',

--- a/thrift_sasl/__init__.py
+++ b/thrift_sasl/__init__.py
@@ -21,6 +21,7 @@
 
 from __future__ import absolute_import
 
+import six
 import sys
 import struct
 
@@ -103,8 +104,7 @@ class TSaslClientTransport(TTransportBase, CReadableTransport):
 
   def _send_message(self, status, body):
     header = struct.pack(">BI", status, len(body))
-    if isinstance(body, str):
-      body = body.encode()
+    body = six.ensure_binary(body)
     self._trans.write(header + body)
     self._trans.flush()
 


### PR DESCRIPTION
Pull request #17 addressed the issue whereby there were occasional
concatenation problems when message header and mesage body were of
different types. However, the original patch, which uses encode(),
was not compatible with python 2 in cases where the body included
characters that fell outside of the strict set of ASCII characters.