### PR TITLE
Change thrift version per python using environment markers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ import sys
 from setuptools import setup
 
 
-PY3 = sys.version_info[0] == 3
 WINDOWS = sys.platform == 'win32' or sys.platform == 'cygwin'
 
 description = ("Thrift SASL Python module that implements SASL transports for "
@@ -32,7 +31,8 @@ setup(
     url='https://github.com/cloudera/thrift_sasl',
     install_requires=[
         # Python 3 support was added to thrift in version 0.10.0.
-        'thrift>=0.10.0' if PY3 else 'thrift==0.9.3',
+        'thrift>=0.10.0; python_version >= "3.0"',
+        'thrift==0.9.3; python_version < "3.0"',
         # Installing sasl on Windows is rather painful, so use the pure python
         # implementation on Windows
         'pure-sasl>=0.3.0' if WINDOWS else 'sasl>=0.2.1',

--- a/setup.py
+++ b/setup.py
@@ -18,36 +18,40 @@ import sys
 from setuptools import setup
 
 
-WINDOWS = sys.platform == 'win32' or sys.platform == 'cygwin'
+WINDOWS = sys.platform == "win32" or sys.platform == "cygwin"
 
-description = ("Thrift SASL Python module that implements SASL transports for "
-               "Thrift (`TSaslClientTransport`).")
+description = (
+    "Thrift SASL Python module that implements SASL transports for "
+    "Thrift (`TSaslClientTransport`)."
+)
 
 setup(
-    name='thrift_sasl',
-    version='0.4.2',
+    name="thrift_sasl",
+    version="0.4.2",
     description=description,
     long_description=description,
-    url='https://github.com/cloudera/thrift_sasl',
+    url="https://github.com/cloudera/thrift_sasl",
     install_requires=[
         # Python 3 support was added to thrift in version 0.10.0.
-        'thrift>=0.10.0; python_version >= "3.0"',
-        'thrift==0.9.3; python_version < "3.0"',
+        "thrift>=0.10.0;python_version>='3.0'",
+        "thrift==0.9.3;python_version<'3.0'",
         # Installing sasl on Windows is rather painful, so use the pure python
         # implementation on Windows
-        'pure-sasl>=0.3.0' if WINDOWS else 'sasl>=0.2.1',
-        'six>=1.13.0'
+        "pure-sasl>=0.3.0;platform_system=='Windows'",
+        "sasl>=0.2.1;platform_system!='Windows'",
+        "six>=1.13.0",
     ],
-    packages=['thrift_sasl'],
-    keywords='thrift sasl transport',
-    license='Apache License, Version 2.0',
+    packages=["thrift_sasl"],
+    keywords="thrift sasl transport",
+    license="Apache License, Version 2.0",
     classifiers=[
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6']
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+    ],
 )


### PR DESCRIPTION
The motivation behind this is that I'm currently facing issues with both `poetry` and the building tool `pants` when they try to resolve the proper version for `thrift`.

They both resolves it to `thrift==0.9.3` even though I'm currently using python 3.7 and if I try to force the `thrift` version manually to the latest one it complains that `thrift_sasl` requires the version `0.9.3`.