### PR TITLE
Unpin thrift version with Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     url='https://github.com/cloudera/thrift_sasl',
     install_requires=[
         # Python 3 support was added to thrift in version 0.10.0.
-        'thrift>=0.10.0' if PY3 else 'thrift==0.9.3',
+        'thrift>=0.10.0' if PY3 else 'thrift>=0.9.3',
         # Installing sasl on Windows is rather painful, so use the pure python
         # implementation on Windows
         'pure-sasl>=0.3.0' if WINDOWS else 'sasl>=0.2.1',


### PR DESCRIPTION
Pinning to 0.9.3 blocks Thrift version upgrade in Impyla.