### PR TITLE
Replace conditional expressions with environment markers in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.4.3
+------
+* **Bug Fixes**
+  - Replaced environment conditionals with environment markers in `setup.py` (#29)
+
 0.4.2
 ------
 * **Bug Fixes**

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,8 @@
 
 from __future__ import absolute_import
 
-import sys
 from setuptools import setup
 
-
-PY3 = sys.version_info[0] == 3
-WINDOWS = sys.platform == 'win32' or sys.platform == 'cygwin'
 
 description = ("Thrift SASL Python module that implements SASL transports for "
                "Thrift (`TSaslClientTransport`).")
@@ -30,13 +26,16 @@ setup(
     description=description,
     long_description=description,
     url='https://github.com/cloudera/thrift_sasl',
+    setup_requires=['setuptools>=36.2'],
     install_requires=[
         # Python 3 support was added to thrift in version 0.10.0.
-        'thrift>=0.10.0' if PY3 else 'thrift==0.9.3',
+        "thrift>=0.10.0;python_version>='3.0'",
+        "thrift==0.9.3;python_version<'3.0'",
         # Installing sasl on Windows is rather painful, so use the pure python
         # implementation on Windows
-        'pure-sasl>=0.3.0' if WINDOWS else 'sasl>=0.2.1',
-        'six>=1.13.0'
+        "pure-sasl>=0.3.0;sys_platform=='win32' or sys_platform=='cygwin'",
+        "sasl>=0.2.1;sys_platform!='win32' and sys_platform!='cygwin'",
+        "six>=1.13.0"
     ],
     packages=['thrift_sasl'],
     keywords='thrift sasl transport',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     description=description,
     long_description=description,
     url='https://github.com/cloudera/thrift_sasl',
-    setup_requires=['setuptools>=36.2'],
+    setup_requires=['setuptools>=20.5'],
     install_requires=[
         # Python 3 support was added to thrift in version 0.10.0.
         "thrift>=0.10.0;python_version>='3.0'",


### PR DESCRIPTION
This PR replaces the conditional expressions in `setup.py` with [environment markers](https://www.python.org/dev/peps/pep-0508/#environment-markers). See [this comment](https://github.com/cloudera/thrift_sasl/pull/26#issuecomment-816132484) for more detail.

One additional thing to note regarding this PR is that it also adds an additional `setup_requires` directive to `setup.py`. This is because the utilization of environment markers necessitates `setuptools>=36.2`. See [here](https://setuptools.readthedocs.io/en/latest/history.html#v36-2-0) for more information.

I tested this PR locally on my Mac (macOS Big Sur) with Python@2.7.18 and Python@3.8.8 and the environment markers do indeed seem to be working correctly when running `python setup.py install`.

## Changelog

0.4.3
------
* **Bug Fixes**
  - Replaced environment conditionals with environment markers in `setup.py` (#29)

Closes #29.